### PR TITLE
Replace PropTypes with TypeScript types

### DIFF
--- a/website/src/components/breadcrumbs.tsx
+++ b/website/src/components/breadcrumbs.tsx
@@ -20,7 +20,7 @@ const build = (
 ) => {
   const name = parts[index] === '' ? 'home' : parts[index];
   if (index === parts.length - ONE) {
-    nav.push(<li>
+    nav.push(<li key={name}>
       <Lang lnkey={name + '.nav'}/>
     </li>,);
     return;
@@ -30,7 +30,7 @@ const build = (
     url += '/' + parts[i];
   }
   url += '/';
-  nav.push(<li>
+  nav.push(<li key={name}>
     <NavLink to={url}>
       <Lang lnkey={name + '.nav'}/>
     </NavLink>

--- a/website/src/components/breadcrumbs.tsx
+++ b/website/src/components/breadcrumbs.tsx
@@ -8,7 +8,10 @@ import {
 import {
   ONE,
 } from '../constants.ts';
-import PropTypes from 'prop-types';
+
+interface BreadcrumbsProps {
+  path: string
+}
 
 const build = (
   index: number,
@@ -36,7 +39,7 @@ const build = (
 
 const Breadcrumbs = ({
   path,
-},) => {
+}: BreadcrumbsProps,) => {
   if (path === '*') {
     return '';
   }
@@ -50,10 +53,6 @@ const Breadcrumbs = ({
       { nav }
     </ul>
   </nav>;
-};
-
-Breadcrumbs.propTypes = {
-  path: PropTypes.string.isRequired,
 };
 
 export default Breadcrumbs;

--- a/website/src/components/default-meta.tsx
+++ b/website/src/components/default-meta.tsx
@@ -3,12 +3,16 @@ import Head from '@uiw/react-head';
 import {
   useTranslation,
 } from 'react-i18next';
-import PropTypes from 'prop-types';
+
+interface DefaultMetaProps {
+  path: string;
+  page: string;
+}
 
 const DefaultMeta = ({
   page,
   path,
-},) => {
+}: DefaultMetaProps,) => {
   const {
     t,
   } = useTranslation();
@@ -21,11 +25,6 @@ const DefaultMeta = ({
     <Head.Title>{title} | @idrinth/api-bench</Head.Title>
     <Head.Link rel='canonical' href={'https://idrinth-api-ben.ch' + path}/>
   </Head>;
-};
-
-DefaultMeta.propTypes = {
-  path: PropTypes.string.isRequired,
-  page: PropTypes.string.isRequired,
 };
 
 export default DefaultMeta;

--- a/website/src/components/lang.tsx
+++ b/website/src/components/lang.tsx
@@ -3,12 +3,16 @@ import {
   Trans,
   useTranslation,
 } from 'react-i18next';
-import PropTypes from 'prop-types';
+
+interface LangProps {
+  lnkey: string;
+  children?: string;
+}
 
 export const Lang = ({
   lnkey,
   ...props
-},) => {
+}: LangProps,) => {
   const {
     t,
   } = useTranslation();
@@ -16,9 +20,4 @@ export const Lang = ({
     props.children = lnkey;
   }
   return <Trans t={t} i18nKey={lnkey}>{props.children}</Trans>;
-};
-
-Lang.propTypes = {
-  lnkey: PropTypes.string.isRequired,
-  children: PropTypes.string.isRequired,
 };

--- a/website/src/components/lang.tsx
+++ b/website/src/components/lang.tsx
@@ -6,18 +6,13 @@ import {
 
 interface LangProps {
   lnkey: string;
-  children?: string;
 }
 
 export const Lang = ({
   lnkey,
-  ...props
 }: LangProps,) => {
   const {
     t,
   } = useTranslation();
-  if (! props.children) {
-    props.children = lnkey;
-  }
-  return <Trans t={t} i18nKey={lnkey}>{props.children}</Trans>;
+  return <Trans t={t} i18nKey={lnkey}>{lnkey}</Trans>;
 };

--- a/website/src/components/layout.tsx
+++ b/website/src/components/layout.tsx
@@ -3,14 +3,20 @@ import Navbar from './navbar.tsx';
 import Footer from './footer.tsx';
 import React from 'react';
 import Breadcrumbs from './breadcrumbs.tsx';
-import PropTypes from 'prop-types';
+
+interface LayoutProps {
+  Outlet: React.ReactNode,
+  page?: string,
+  path?: string,
+  canonical?: string,
+}
 
 const Layout = ({
   Outlet,
   page = '',
   path = '',
   canonical = '',
-},) => {
+}: LayoutProps,) => {
   const meta = page
     ? <DefaultMeta page={page} path={canonical ? canonical : path}/>
     : '';
@@ -23,13 +29,6 @@ const Layout = ({
     </article>
     <Footer/>
   </>;
-};
-
-Layout.propTypes = {
-  Outlet: PropTypes.element.isRequired,
-  page: PropTypes.string.isRequired,
-  path: PropTypes.string.isRequired,
-  canonical: PropTypes.string.isRequired,
 };
 
 export default Layout;

--- a/website/src/components/loader.tsx
+++ b/website/src/components/loader.tsx
@@ -3,18 +3,18 @@ import Layout from './layout.tsx';
 import {
   Lang,
 } from './lang.tsx';
-import PropTypes from 'prop-types';
+
+interface LoaderProps {
+  lnkey: string;
+}
 
 const Loader = ({
   lnkey,
-},) => <Layout
+}: LoaderProps,) => <Layout
   Outlet={<div id='loader'>
     <span></span>
     <strong><Lang lnkey={lnkey}/></strong>
   </div>}
 />;
 
-Loader.propTypes = {
-  lnkey: PropTypes.string.isRequired,
-};
 export default Loader;


### PR DESCRIPTION
# The Pull Request is ready

- [x] fixes #403 
- [ ] all actions are passing
- [x] only fixes a single issue

## Overview

<!-- Provide a brief description of the changes introduced by this PR. -->
Replaces runtime type checking introduced with PropTypes package with static type checking using TypeScript

Also added keys to the list items in breadcrumbs component to fix React warning about not using keys in list items
See: https://sentry.io/answers/unique-key-prop/ 

## Website

- [x] mobile view is usable
- [x] desktop view is usable
- [x] no a-tags are used directly (NavLink, MailLink, ExternalLink instead)
- [ ] all new texts are added to the translation files (at least the english one)
- [ ] tests have been added (if required)
- [ ] shared code has been extracted in a different file

## Notes

<!-- Write any note or comment. You can share your thoughts or ideas. -->
<!-- Delete this section if not needed -->
Please check if using `name` as a key is unique enough, couldn't think of anything else.
Didn't intend to add the keys in this PR but I found it by chance while checking if everything is fine in the website
