### PR TITLE
Add commit messages guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,7 @@ build(website): bump follow-redirects from 1.15.4 to 1.15.6
 #### Type
 
 The list of supported types:
+
 - `build`: Changes that affect the build system or external dependencies
 - `ci`: Changes to CI configuration files and scripts
 - `docs`: Documentation changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,7 +107,6 @@ build(website): bump follow-redirects from 1.15.4 to 1.15.6
 #### Type
 
 The list of supported types:
-
 - `build`: Changes that affect the build system or external dependencies
 - `ci`: Changes to CI configuration files and scripts
 - `docs`: Documentation changes
@@ -137,10 +136,10 @@ The summary field should provide a succinct description of the change.
 
 ```js
 // Bad:
-Fixes a bug.
+Fixes unit tests failing.
 
 // Good:
-fix a bug
+fix unit tests failing
 ```
 
 ### Commit Message Body

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing
 
-Any and all contributions are encouraged. As a contributor, here are the guidelines we would like you to follow:
+Any and all contributions are encouraged. As a contributor,
+here are the guidelines we would like you to follow:
 
 - [Issues](#issues)
 - [Code](#code)
@@ -82,12 +83,15 @@ Each commit message consists of a **header**, a **body**, and a **footer**.
 <footer>
 ```
 
-The `header` is mandatory and should conform to the [Commit Message Header](#commit-message-header) format.
+The `header` is mandatory and should conform to the 
+[Commit Message Header](#commit-message-header) format.
 
-The `body` is mandatory for all commits except for those of type "docs" or in cases when it's clear from the header summary.  
-They should conform to the [Commit Message Body](#commit-message-body) format.
+The `body` is mandatory for all commits except for those of type "docs"
+or in cases when it's clear from the header summary. They should conform 
+to the [Commit Message Body](#commit-message-body) format.
 
-The `footer` is optional. The [Commit Message Footer](#commit-message-footer) format describes what the footer is used for and the structure it must have.
+The `footer` is optional. The [Commit Message Footer](#commit-message-footer)
+format describes what the footer is used for and the structure it must have.
 
 ### Commit Message Header
 
@@ -115,7 +119,8 @@ The list of supported types:
 
 #### Scope
 
-The scope should be the name of the affected part of the project. The list of supported scopes:
+The scope should be the name of the affected part of the project.
+The list of supported scopes:
 
 - `framework`
 - `website`
@@ -142,11 +147,17 @@ fix a bug
 
 Just as in the summary, use the imperative, present tense.
 
-The commit message body should explain *why* you are making the change. You can include a comparison of the previous behaviour with the new behaviour in order to illustrate the impact of the change.
+The commit message body should explain *why* you are making the change.
+You can include a comparison of the previous behaviour with the new
+behaviour in order to illustrate the impact of the change.
 
 ### Commit Message Footer
 
-The footer can contain information about breaking changes and deprecation and is also the place to reference GitHub issues and other PR's that this commit closes or is related to. In case of breaking changes and deprecation the section should start with the phrase "BREAKING CHANGE: " or "DEPRECATED: " respectively followed by a description. For example:
+The footer can contain information about breaking changes and deprecation
+and is also the place to reference GitHub issues and other PR's that this
+commit closes or is related to. In case of breaking changes and deprecation
+the section should start with the phrase "BREAKING CHANGE: " or "DEPRECATED: "
+respectively followed by a description. For example:
 
 ```md
 BREAKING CHANGE: users must now provide a valid JWT token to access protected routes.
@@ -159,14 +170,16 @@ Here's a complete example of a correct commit message:
 ```md
 fix(framework): resolve issue with string injection from env
 
-Fix a bug where given a function route definition that has a string-typed or untyped parameter, the value would never be injected from the environment.
+Fix a bug where given a function route definition that has a string-typed
+or untyped parameter, the value would never be injected from the environment.
 
 Closes #294
 ```
 
 ### Revert commits
 
-If the commit reverts a previous commit, it should begin with `revert:`, followed by the header of the reverted commit.
+If the commit reverts a previous commit, it should begin with `revert:`,
+followed by the header of the reverted commit.
 
 The content of the commit message body should contain:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,17 @@
 # Contributing
 
-Any and all contributions are encouraged.
+Any and all contributions are encouraged. As a contributor, here are the guidelines we would like you to follow:
 
-## Issues
+- [Issues](#issues)
+- [Code](#code)
+- [Commit Message Guidelines](#commits)
+- [Documentation](#docs)
+
+## <a name="issues"></a>Issues
 
 Any idea and bug report is considered a contribution. Not only do they help improving the code base, they help other people to get more use out of this framework. Please try to stick to the format of predefined issue types to make it easier to filter and handle for anyone interested in the topic.
 
-## Code
+## <a name="code"></a>Code
 
 The style guidelines are provided via eslint. Please try to optimise code for readability, since code will be read way more often than it will be changed.
 
@@ -60,7 +65,112 @@ cd api-bench
 npm run setup
 ```
 
-## Documentation
+## <a name="commits"></a> Commit Message Guidelines
+
+**This specification is inspired by Angular commit messages guidelines.*
+
+These are the rules for how Git commit messages for api-bench should be formatted.
+This format leads to easier to read commit history.
+
+Each commit message consists of a **header**, a **body**, and a **footer**.
+
+```md
+<header>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+The `header` is mandatory and should conform to the [Commit Message Header](#commit-header) format.
+
+The `body` is mandatory for all commits except for those of type "docs" or in cases when it's clear from the header summary.  
+They should conform to the [Commit Message Body](#commit-body) format.
+
+The `footer` is optional. The [Commit Message Footer](#commit-footer) format describes what the footer is used for and the structure it must have.
+
+### <a name="commit-header"></a>Commit Message Header
+
+Headers must adhere to the following format:
+```md
+<type>(<scope>): <short summary>
+
+Example:
+build(website): bump follow-redirects from 1.15.4 to 1.15.6
+```
+
+#### Type
+
+The list of supported types:
+
+* `build`: Changes that affect the build system or external dependencies
+* `ci`: Changes to CI configuration files and scripts
+* `docs`: Documentation changes
+* `feature`: A new feature
+* `fix`: A bug fix
+* `perf`: A code change that improves performance
+* `refactor`: A code change that neither fixes a bug nor adds a feature
+* `test`: Adding missing tests or correcting existing tests
+
+#### Scope
+The scope should be the name of the affected part of the project. The list of supported scopes:
+
+- `framework`
+- `website`
+- `history-microservice`
+- `history-website`
+
+#### Summary
+
+The summary field should provide a succinct description of the change. 
+- use the imperative, present tense
+- don't capitalize the first letter
+- no dot (.) at the end
+
+```
+Bad:
+Fixes a bug.
+
+Good:
+fix a bug
+```
+
+### <a name="commit-body"></a>Commit Message Body
+
+Just as in the summary, use the imperative, present tense.
+
+The commit message body should explain _why_ you are making the change. You can include a comparison of the previous behavior with the new behavior in order to illustrate the impact of the change.
+
+### <a name="commit-footer"></a>Commit Message Footer
+
+The footer can contain information about breaking changes and deprecations and is also the place to reference GitHub issues and other PRs that this commit closes or is related to. In case of breaking changes and deprecations the section should start with the phrase "BREAKING CHANGE: " or "DEPRECATED: " respectively followed by a description. For example:
+
+```
+BREAKING CHANGE: users must now provide a valid JWT token to access protected routes.
+
+Closes #123
+```
+
+Here's a complete example of a correct commit message:
+
+```
+fix(framework): resolve issue with string injection from env
+
+Fix a bug where given a function route definition that has a string-typed or untyped parameter, the value would never be injected from the environment.
+
+Closes #294
+```
+
+### Revert commits
+
+If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit.
+
+The content of the commit message body should contain:
+
+- information about the SHA of the commit being reverted in the following format: `This reverts commit <SHA>`,
+- a clear description of the reason for reverting the commit message.
+
+## <a name="docs"></a>Documentation
 
 Documentation is an underrated part of every software. Adding any kind of clarification, example or improvement is highly appreciated and encouraged. The ones writing the documentation are the unsung heroes of open and closed source software.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,14 +4,14 @@ Any and all contributions are encouraged. As a contributor, here are the guideli
 
 - [Issues](#issues)
 - [Code](#code)
-- [Commit Message Guidelines](#commits)
-- [Documentation](#docs)
+- [Commit Message Guidelines](#commit-message-guidelines)
+- [Documentation](#documentation)
 
-## <a name="issues"></a>Issues
+## Issues
 
 Any idea and bug report is considered a contribution. Not only do they help improving the code base, they help other people to get more use out of this framework. Please try to stick to the format of predefined issue types to make it easier to filter and handle for anyone interested in the topic.
 
-## <a name="code"></a>Code
+## Code
 
 The style guidelines are provided via eslint. Please try to optimise code for readability, since code will be read way more often than it will be changed.
 
@@ -65,7 +65,7 @@ cd api-bench
 npm run setup
 ```
 
-## <a name="commits"></a> Commit Message Guidelines
+## Commit Message Guidelines
 
 **This specification is inspired by Angular commit messages guidelines.*
 
@@ -82,14 +82,14 @@ Each commit message consists of a **header**, a **body**, and a **footer**.
 <footer>
 ```
 
-The `header` is mandatory and should conform to the [Commit Message Header](#commit-header) format.
+The `header` is mandatory and should conform to the [Commit Message Header](#commit-message-header) format.
 
 The `body` is mandatory for all commits except for those of type "docs" or in cases when it's clear from the header summary.  
-They should conform to the [Commit Message Body](#commit-body) format.
+They should conform to the [Commit Message Body](#commit-message-body) format.
 
-The `footer` is optional. The [Commit Message Footer](#commit-footer) format describes what the footer is used for and the structure it must have.
+The `footer` is optional. The [Commit Message Footer](#commit-message-footer) format describes what the footer is used for and the structure it must have.
 
-### <a name="commit-header"></a>Commit Message Header
+### Commit Message Header
 
 Headers must adhere to the following format:
 
@@ -138,13 +138,13 @@ Fixes a bug.
 fix a bug
 ```
 
-### <a name="commit-body"></a>Commit Message Body
+### Commit Message Body
 
 Just as in the summary, use the imperative, present tense.
 
 The commit message body should explain *why* you are making the change. You can include a comparison of the previous behaviour with the new behaviour in order to illustrate the impact of the change.
 
-### <a name="commit-footer"></a>Commit Message Footer
+### Commit Message Footer
 
 The footer can contain information about breaking changes and deprecation and is also the place to reference GitHub issues and other PR's that this commit closes or is related to. In case of breaking changes and deprecation the section should start with the phrase "BREAKING CHANGE: " or "DEPRECATED: " respectively followed by a description. For example:
 
@@ -173,7 +173,7 @@ The content of the commit message body should contain:
 - ID of the commit being reverted in the following format: `This reverts commit <SHA>`,
 - a clear description of the reason for reverting the commit message.
 
-## <a name="docs"></a>Documentation
+## Documentation
 
 Documentation is an underrated part of every software. Adding any kind of clarification, example or improvement is highly appreciated and encouraged. The ones writing the documentation are the unsung heroes of open and closed source software.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,11 +83,11 @@ Each commit message consists of a **header**, a **body**, and a **footer**.
 <footer>
 ```
 
-The `header` is mandatory and should conform to the 
+The `header` is mandatory and should conform to the
 [Commit Message Header](#commit-message-header) format.
 
 The `body` is mandatory for all commits except for those of type "docs"
-or in cases when it's clear from the header summary. They should conform 
+or in cases when it's clear from the header summary. They should conform
 to the [Commit Message Body](#commit-message-body) format.
 
 The `footer` is optional. The [Commit Message Footer](#commit-message-footer)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,7 @@ The `footer` is optional. The [Commit Message Footer](#commit-footer) format des
 ### <a name="commit-header"></a>Commit Message Header
 
 Headers must adhere to the following format:
+
 ```md
 <type>(<scope>): <short summary>
 
@@ -103,16 +104,17 @@ build(website): bump follow-redirects from 1.15.4 to 1.15.6
 
 The list of supported types:
 
-* `build`: Changes that affect the build system or external dependencies
-* `ci`: Changes to CI configuration files and scripts
-* `docs`: Documentation changes
-* `feature`: A new feature
-* `fix`: A bug fix
-* `perf`: A code change that improves performance
-* `refactor`: A code change that neither fixes a bug nor adds a feature
-* `test`: Adding missing tests or correcting existing tests
+- `build`: Changes that affect the build system or external dependencies
+- `ci`: Changes to CI configuration files and scripts
+- `docs`: Documentation changes
+- `feature`: A new feature
+- `fix`: A bug fix
+- `perf`: A code change that improves performance
+- `refactor`: A code change that neither fixes a bug nor adds a feature
+- `test`: Adding missing tests or correcting existing tests
 
 #### Scope
+
 The scope should be the name of the affected part of the project. The list of supported scopes:
 
 - `framework`
@@ -122,16 +124,17 @@ The scope should be the name of the affected part of the project. The list of su
 
 #### Summary
 
-The summary field should provide a succinct description of the change. 
+The summary field should provide a succinct description of the change.
+
 - use the imperative, present tense
-- don't capitalize the first letter
+- don't capitalise the first letter
 - no dot (.) at the end
 
-```
-Bad:
+```js
+// Bad:
 Fixes a bug.
 
-Good:
+// Good:
 fix a bug
 ```
 
@@ -139,13 +142,13 @@ fix a bug
 
 Just as in the summary, use the imperative, present tense.
 
-The commit message body should explain _why_ you are making the change. You can include a comparison of the previous behavior with the new behavior in order to illustrate the impact of the change.
+The commit message body should explain *why* you are making the change. You can include a comparison of the previous behaviour with the new behaviour in order to illustrate the impact of the change.
 
 ### <a name="commit-footer"></a>Commit Message Footer
 
-The footer can contain information about breaking changes and deprecations and is also the place to reference GitHub issues and other PRs that this commit closes or is related to. In case of breaking changes and deprecations the section should start with the phrase "BREAKING CHANGE: " or "DEPRECATED: " respectively followed by a description. For example:
+The footer can contain information about breaking changes and deprecation and is also the place to reference GitHub issues and other PR's that this commit closes or is related to. In case of breaking changes and deprecation the section should start with the phrase "BREAKING CHANGE: " or "DEPRECATED: " respectively followed by a description. For example:
 
-```
+```md
 BREAKING CHANGE: users must now provide a valid JWT token to access protected routes.
 
 Closes #123
@@ -153,7 +156,7 @@ Closes #123
 
 Here's a complete example of a correct commit message:
 
-```
+```md
 fix(framework): resolve issue with string injection from env
 
 Fix a bug where given a function route definition that has a string-typed or untyped parameter, the value would never be injected from the environment.
@@ -163,11 +166,11 @@ Closes #294
 
 ### Revert commits
 
-If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit.
+If the commit reverts a previous commit, it should begin with `revert:`, followed by the header of the reverted commit.
 
 The content of the commit message body should contain:
 
-- information about the SHA of the commit being reverted in the following format: `This reverts commit <SHA>`,
+- ID of the commit being reverted in the following format: `This reverts commit <SHA>`,
 - a clear description of the reason for reverting the commit message.
 
 ## <a name="docs"></a>Documentation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ The summary field should provide a succinct description of the change.
 - don't capitalise the first letter
 - no dot (.) at the end
 
-```js
+```md
 // Bad:
 Fixes unit tests failing.
 

--- a/framework/package-lock.json
+++ b/framework/package-lock.json
@@ -2324,9 +2324,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.5.tgz",
-      "integrity": "sha512-sWvP1Pl8H03B8oFJpFR3HE31HUfwtX7Rlf9BNsvdpujD4n7WMhfmu8h9wOV2u+c1k0ZilTADhPqypzx2J690ZQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.6.tgz",
+      "integrity": "sha512-M2SovcRxD4+vC493Uc2GZVcZaj66CCJhWurC4viynVSTvrpErCShNcDz1lAho6n9REQKvL/ll4A4/fw6Y9z8nw==",
       "funding": [
         {
           "type": "github",

--- a/website/src/pages/contributing/contributing.css
+++ b/website/src/pages/contributing/contributing.css
@@ -1,0 +1,30 @@
+html {
+  --code-text: rgb(68, 68, 68);
+  --code-bg: rgb(240, 240, 240);
+}
+
+.preface {
+  font-style: italic;
+}
+.code-block {
+  font-family: monospace;
+  background-color: var(--code-bg);
+  color: var(--code-text);
+  display: block;
+  padding: 1.5rem;
+  border-radius: 4px;
+
+  p {
+    padding: 0;
+  }
+}
+.mono-text {
+  font-family: monospace;
+  background-color: var(--code-bg);
+  color: var(--code-text);
+  padding: 0 4px 0 4px;
+  border-radius: 4px;
+}
+.card-list > li {
+  margin: .5rem 0;
+}

--- a/website/src/pages/contributing/contributing.css
+++ b/website/src/pages/contributing/contributing.css
@@ -7,20 +7,6 @@ html {
   font-style: italic;
 }
 
-.code-block {
-  font-family: monospace;
-  background-color: var(--code-bg);
-  color: var(--code-text);
-  display: block;
-  padding: 1.5rem;
-  border-radius: 4px;
-
-}
-
-.code-block p {
-  padding: 0;
-}
-
 .mono-text {
   font-family: monospace;
   background-color: var(--code-bg);

--- a/website/src/pages/contributing/contributing.css
+++ b/website/src/pages/contributing/contributing.css
@@ -1,11 +1,12 @@
 html {
-  --code-text: rgb(68, 68, 68);
-  --code-bg: rgb(240, 240, 240);
+  --code-text: rgb(68 68 68);
+  --code-bg: rgb(240 240 240);
 }
 
 .preface {
   font-style: italic;
 }
+
 .code-block {
   font-family: monospace;
   background-color: var(--code-bg);
@@ -14,17 +15,20 @@ html {
   padding: 1.5rem;
   border-radius: 4px;
 
-  p {
-    padding: 0;
-  }
 }
+
+.code-block p {
+  padding: 0;
+}
+
 .mono-text {
   font-family: monospace;
   background-color: var(--code-bg);
   color: var(--code-text);
-  padding: 0 4px 0 4px;
+  padding: 0 4px;
   border-radius: 4px;
 }
+
 .card-list > li {
   margin: .5rem 0;
 }

--- a/website/src/pages/contributing/index.tsx
+++ b/website/src/pages/contributing/index.tsx
@@ -251,7 +251,7 @@ Closes #294
 
         <h3>Revert commits</h3>
         <p>If the commit reverts a previous commit, it should begin with
-          <span className="mono-text">revert: </span>, followed by the header
+          <span className="mono-text">revert:</span>, followed by the header
           of the reverted commit.
         </p>
         <p>The content of the commit message body should contain:</p>

--- a/website/src/pages/contributing/index.tsx
+++ b/website/src/pages/contributing/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import Layout from '../../components/layout.tsx';
+import './contributing.css';
 
 const Index = () => <Layout
   Outlet={<section>
@@ -110,6 +111,162 @@ npm run coai
   cd api-bench
   npm run setup
         `}</SyntaxHighlighter>
+      </div>
+    </div>
+    <div className="card">
+      <h2>Commit Message Guidelines</h2>
+      <div>
+        <p className="preface">*This specification is inspired by Angular commit
+          messages guidelines.
+        </p>
+        <p>These are the rules for how Git commit messages for api-bench should
+          be formatted. This format leads to easier to read commit history.
+        </p>
+        <p>Each commit message consists of a <strong>header</strong>,
+          a <strong>body</strong>, and a <strong>footer</strong>.
+        </p>
+        <code className="code-block">
+          <p>&lt;header&gt;</p>
+          <p>&#47;&#47; BLANK LINE</p>
+          <p>&lt;body&gt;</p>
+          <p>&#47;&#47; BLANK LINE</p>
+          <p>&lt;footer&gt;</p>
+        </code>
+        <p>The <span className="mono-text">header</span> is mandatory and
+          should conform to the Commit Message Header format.
+        </p>
+        <p>
+          The <span className="mono-text">body</span> is mandatory for
+          all commits except for those of type &quot;docs&quot; or in cases when
+          it&apos;s clear from the header summary. They should conform to the
+          Commit Message Body format.
+        </p>
+        <p>
+          The <span className="mono-text">footer</span> is optional.
+          The Commit Message Footer format describes what the footer is used
+          for and the structure it must have.
+        </p>
+
+        <h3>Commit Message Header</h3>
+        <p>Headers must adhere to the following format:</p>
+        <code className="code-block">
+          <p>&lt;type&gt;(&lt;scope&gt;): &lt;short summary&gt;</p>
+          <br />
+          <p>Example:</p>
+          build(website): bump follow-redirects from 1.15.4 to 1.15.6
+        </code>
+        <h4>Type</h4>
+        <p>The list of supported types:</p>
+        <ul className="card-list">
+          <li>
+            <span className="mono-text">build</span>: Changes that affect
+            the build system or external dependencies
+          </li>
+          <li>
+            <span className="mono-text">ci</span>: Changes to CI configuration
+            files and scripts
+          </li>
+          <li>
+            <span className="mono-text">docs</span>: Documentation changes
+          </li>
+          <li>
+            <span className="mono-text">feature</span>: A new feature
+          </li>
+          <li>
+            <span className="mono-text">fix</span>: A bug fix
+          </li>
+          <li>
+            <span className="mono-text">perf</span>: A code change that
+            improves performance
+          </li>
+          <li>
+            <span className="mono-text">refactor</span>: A code change
+            that neither fixes a bug nor adds a feature
+          </li>
+          <li>
+            <span className="mono-text">test</span>: Adding missing tests
+            or correcting existing tests
+          </li>
+        </ul>
+        <h4>Scope</h4>
+        <p>The scope should be the name of the affected part of the project.
+          The list of supported scopes:</p>
+        <ul className="card-list">
+          <li><span className="mono-text">framework</span></li>
+          <li><span className="mono-text">website</span></li>
+          <li><span className="mono-text">history-microservice</span></li>
+          <li><span className="mono-text">history-website</span></li>
+        </ul>
+        <h4>Summary</h4>
+        <p>The summary field should provide a succinct description of
+          the change.</p>
+        <ul className="card-list">
+          <li>use the imperative, present tense</li>
+          <li>don&apos;t capitalize the first letter</li>
+          <li>no dot (.) at the end</li>
+        </ul>
+        <code className="code-block">
+          <p>&#47;&#47; Bad:</p>
+          <p>Fixes a bug.</p>
+          <br />
+          <p>&#47;&#47; Good:</p>
+          <p>fix a bug</p>
+        </code>
+
+        <h3>Commit Message Body</h3>
+        <p>Just as in the summary, use the imperative, present tense.</p>
+        <p>The commit message body should explain why you are making
+          the change. You can include a comparison of the previous behavior
+          with the new behavior in order to illustrate the impact of the change.
+        </p>
+
+        <h3>Commit Message Footer</h3>
+        <p>
+          The footer can contain information about breaking changes and
+          deprecations and is also the place to reference GitHub issues and
+          other PRs that this commit closes or is related to.
+        </p>
+        <p>
+          In case of
+          breaking changes and deprecations the section should start with
+          the phrase &quot;BREAKING CHANGE: &quot; or
+          &quot;DEPRECATED: &quot; respectively followed by a description.
+          For example:
+        </p>
+        <code className="code-block">
+          <p>BREAKING CHANGE: users must now provide a valid JWT token to
+            access protected routes.</p>
+          <br />
+          Closes #123
+        </code>
+        <p>Here&apos;s a complete example of a correct commit message:</p>
+        <code className="code-block">
+          <p>fix(framework): resolve issue with string injection from env</p>
+          <br />
+          <p>
+            Fix a bug where given a function route definition that has a
+            string-typed or untyped parameter, the value would never be
+            injected from the environment.
+          </p>
+          <br />
+          Closes #294
+        </code>
+
+        <h3>Revert commits</h3>
+        <p>If the commit reverts a previous commit, it should begin with
+          <span className="mono-text">revert: </span>, followed by the header
+          of the reverted commit.
+        </p>
+        <p>The content of the commit message body should contain:</p>
+        <ul className="card-list">
+          <li>information about the SHA of the commit being reverted in
+            the following format: <span className="mono-text">This
+            reverts commit &lt;SHA&gt;</span>
+          </li>
+          <li>
+            a clear description of the reason for reverting the commit message.
+          </li>
+        </ul>
       </div>
     </div>
     <div className='card'>

--- a/website/src/pages/contributing/index.tsx
+++ b/website/src/pages/contributing/index.tsx
@@ -125,13 +125,13 @@ npm run coai
         <p>Each commit message consists of a <strong>header</strong>,
           a <strong>body</strong>, and a <strong>footer</strong>.
         </p>
-        <code className="code-block">
-          <p>&lt;header&gt;</p>
-          <p>&#47;&#47; BLANK LINE</p>
-          <p>&lt;body&gt;</p>
-          <p>&#47;&#47; BLANK LINE</p>
-          <p>&lt;footer&gt;</p>
-        </code>
+        <SyntaxHighlighter language='markdown'>{`
+<header>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+        `}</SyntaxHighlighter>
         <p>The <span className="mono-text">header</span> is mandatory and
           should conform to the Commit Message Header format.
         </p>
@@ -149,12 +149,12 @@ npm run coai
 
         <h3>Commit Message Header</h3>
         <p>Headers must adhere to the following format:</p>
-        <code className="code-block">
-          <p>&lt;type&gt;(&lt;scope&gt;): &lt;short summary&gt;</p>
-          <br />
-          <p>Example:</p>
-          build(website): bump follow-redirects from 1.15.4 to 1.15.6
-        </code>
+        <SyntaxHighlighter language='bash'>{`
+<type>(<scope>): <short summary>
+
+Example:
+build(website): bump follow-redirects from 1.15.4 to 1.15.6
+        `}</SyntaxHighlighter>
         <h4>Type</h4>
         <p>The list of supported types:</p>
         <ul className="card-list">
@@ -205,13 +205,13 @@ npm run coai
           <li>don&apos;t capitalize the first letter</li>
           <li>no dot (.) at the end</li>
         </ul>
-        <code className="code-block">
-          <p>&#47;&#47; Bad:</p>
-          <p>Fixes a bug.</p>
-          <br />
-          <p>&#47;&#47; Good:</p>
-          <p>fix a bug</p>
-        </code>
+        <SyntaxHighlighter language='markdown'>{`
+// Bad:
+Fixes unit tests failing.
+
+// Good:
+fix unit tests failing
+        `}</SyntaxHighlighter>
 
         <h3>Commit Message Body</h3>
         <p>Just as in the summary, use the imperative, present tense.</p>
@@ -233,24 +233,21 @@ npm run coai
           &quot;DEPRECATED: &quot; respectively followed by a description.
           For example:
         </p>
-        <code className="code-block">
-          <p>BREAKING CHANGE: users must now provide a valid JWT token to
-            access protected routes.</p>
-          <br />
-          Closes #123
-        </code>
+        <SyntaxHighlighter language='markdown'>{`
+BREAKING CHANGE: users must now provide a valid JWT token to access
+protected routes.
+
+Closes #123
+        `}</SyntaxHighlighter>
         <p>Here&apos;s a complete example of a correct commit message:</p>
-        <code className="code-block">
-          <p>fix(framework): resolve issue with string injection from env</p>
-          <br />
-          <p>
-            Fix a bug where given a function route definition that has a
-            string-typed or untyped parameter, the value would never be
-            injected from the environment.
-          </p>
-          <br />
-          Closes #294
-        </code>
+        <SyntaxHighlighter language='markdown'>{`
+fix(framework): resolve issue with string injection from env
+
+Fix a bug where given a function route definition that has a string-typed
+or untyped parameter, the value would never be injected from the environment.
+
+Closes #294
+        `}</SyntaxHighlighter>
 
         <h3>Revert commits</h3>
         <p>If the commit reverts a previous commit, it should begin with


### PR DESCRIPTION
- [ ] fixes #406 
- [ ] all actions are passing
- [ ] only fixes a single issue

## Overview

Adds commit messages guidelines to contribution README file as well as the website contribution page.

## Review points

The current list of supported scopes and types of commit messages needs to be looked at to determine sufficiency to the project. Also, depending on the needed stringency of the messages, the requirements to them can be mitigated/enhanced.

## Framework

- [ ] the change breaks no interface
- [ ] default behaviour did not change
- [ ] any new text output is added to the translation files (at least the english one)
- [ ] tests have been added (if required)
- [ ] documentation has been adjusted (if required)
- [ ] shared code has been extracted in a different file

## Website

- [ ] mobile view is useable
- [ ] desktop view is useable
- [ ] no a-tags are used direktly (NavLink, MailLink, ExternalLink instead)
- [ ] all new texts are added to the translation files (at least the english one)
- [ ] tests have been added (if required)
- [ ] shared code has been extracted in a different file
