### PR TITLE
bug(website): code highlighting style fix

### DIFF
--- a/website/src/components/Code.tsx
+++ b/website/src/components/Code.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import SyntaxHighlighter from 'react-syntax-highlighter';
+import './code.css';
+
+interface CodeType {
+  language: string,
+  children: string|string[],
+}
+
+const Code = ({
+  language,
+  children,
+}: CodeType,) => <SyntaxHighlighter
+  useInlineStyles={false}
+  language={language}>{children}</SyntaxHighlighter>;
+
+export default Code;

--- a/website/src/components/code.css
+++ b/website/src/components/code.css
@@ -2,18 +2,23 @@
   background: #dbdbdb;
   padding: 0.5em;
 }
+
 .dark-mode .hljs {
    background: #242424;
 }
+
 .hljs .hljs-keyword {
   color: orange;
 }
+
 .hljs .hljs-built_in {
   color: darkorange;
 }
+
 .hljs .hljs-string {
   color: green;
 }
+
 .hljs .hljs-attr {
   color: blue;
 }

--- a/website/src/components/code.css
+++ b/website/src/components/code.css
@@ -1,0 +1,19 @@
+.hljs {
+  background: #dbdbdb;
+  padding: 0.5em;
+}
+.dark-mode .hljs {
+   background: #242424;
+}
+.hljs .hljs-keyword {
+  color: orange;
+}
+.hljs .hljs-built_in {
+  color: darkorange;
+}
+.hljs .hljs-string {
+  color: green;
+}
+.hljs .hljs-attr {
+  color: blue;
+}

--- a/website/src/pages/usage/autowiring/index.tsx
+++ b/website/src/pages/usage/autowiring/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import SyntaxHighlighter from 'react-syntax-highlighter';
 import Layout from '../../../components/layout.tsx';
+import Code from '../../../components/Code.tsx';
 
 const AutoWiring = () => <Layout
   Outlet={<>
@@ -36,7 +36,7 @@ const AutoWiring = () => <Layout
     </div>
     <div className='card'>
       <h2>Example</h2>
-      <SyntaxHighlighter language='javascript'>
+      <Code language='javascript'>
         {`module.exports = (apiRootUrl, apiEMail, apiPassword) => ({
   id: 'login',
   main: {
@@ -58,7 +58,7 @@ const AutoWiring = () => <Layout
   ],
 });
   `}
-      </SyntaxHighlighter>
+      </Code>
     </div>
   </>}
   page='autowiring'

--- a/website/src/pages/usage/logging/index.tsx
+++ b/website/src/pages/usage/logging/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import SyntaxHighlighter from 'react-syntax-highlighter';
 import {
   Lang,
 } from '../../../components/lang.tsx';
 import Layout from '../../../components/layout.tsx';
+import Code from '../../../components/Code.tsx';
 
 const Logging = () => <Layout
   Outlet={<>
@@ -27,7 +27,7 @@ const Logging = () => <Layout
           You can implement the logger interface below and provide any logger
           you want to next to the already provided ones.
         </p>
-        <SyntaxHighlighter language='typescript'>
+        <Code language='typescript'>
           {`interface Logger {
   trace(msg: string, data: Record<string, unknown>): void;
   trace(msg: string): void;
@@ -42,7 +42,7 @@ const Logging = () => <Layout
   fatal(msg: string, data: Record<string, unknown>): void;
   fatal(msg: string): void;
 }`}
-        </SyntaxHighlighter>
+        </Code>
         <p>
           <Lang lnkey={'logging.custom.final'}/>
         </p>

--- a/website/src/pages/usage/middlewares/index.tsx
+++ b/website/src/pages/usage/middlewares/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import SyntaxHighlighter from 'react-syntax-highlighter';
 import Layout from '../../../components/layout.tsx';
+import Code from '../../../components/Code.tsx';
 
 const Middlewares = () => <Layout
   Outlet={<>
@@ -40,12 +40,12 @@ const Middlewares = () => <Layout
           called before sending a request, process after a request. If an error
           is thrown in process, any further validations are skipped.
         </p>
-        <SyntaxHighlighter language='typescript'>
+        <Code language='typescript'>
           {`interface Middleware {
   process(response: Result): void;
   prepare(request: Request): Request;
 }`}
-        </SyntaxHighlighter>
+        </Code>
       </div>
     </div>
   </>}

--- a/website/src/pages/usage/results/index.tsx
+++ b/website/src/pages/usage/results/index.tsx
@@ -3,8 +3,8 @@ import CsvReport from '../../../assets/csv-result.jpg';
 import ApiBenchReport from '../../../assets/html-result.jpg';
 import CliReport from '../../../assets/cli-result.jpg';
 import JsonReport from '../../../assets/json-result.jpg';
-import SyntaxHighlighter from 'react-syntax-highlighter';
 import Layout from '../../../components/layout.tsx';
+import Code from '../../../components/Code.tsx';
 
 const Results = () => <Layout
   Outlet={<>
@@ -65,11 +65,11 @@ const Results = () => <Layout
           It will be called with the complete result after all result
           modifiers have modified the result.
         </p>
-        <SyntaxHighlighter language='typescript'>
+        <Code language='typescript'>
           {`interface Reporter {
   (results: FinishedRun, rootDir: string): void;
 }`}
-        </SyntaxHighlighter>
+        </Code>
       </div>
     </div>
   </>}

--- a/website/src/pages/usage/routes/index.tsx
+++ b/website/src/pages/usage/routes/index.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import {
   Lang,
 } from '../../../components/lang.tsx';
-import SyntaxHighlighter from 'react-syntax-highlighter';
 import Layout from '../../../components/layout.tsx';
+import Code from '../../../components/Code.tsx';
 
 const Route = () => <Layout
   Outlet={<>
@@ -15,7 +15,7 @@ const Route = () => <Layout
       <h2><Lang lnkey='routes.example.title'/></h2>
       <div>
         <p><Lang lnkey='routes.example.description'/></p>
-        <SyntaxHighlighter language='typescript'>{`import {
+        <Code language='typescript'>{`import {
   Task,
 } from '@idrinth/api-bench';
   
@@ -25,7 +25,7 @@ export default (apiURL, apiPassword): Task => {
     url: apiURL + '?' + apiPassword,
   },
 };
-      `}</SyntaxHighlighter>
+      `}</Code>
       </div>
     </div>
   </>}

--- a/website/src/pages/usage/storage/index.tsx
+++ b/website/src/pages/usage/storage/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import SyntaxHighlighter from 'react-syntax-highlighter';
 import {
   Lang,
 } from '../../../components/lang.tsx';
 import Layout from '../../../components/layout.tsx';
+import Code from '../../../components/Code.tsx';
 
 const Storage = () => <Layout
   Outlet={<>
@@ -19,12 +19,12 @@ const Storage = () => <Layout
         <p>
           <Lang lnkey='storage.custom.description'/>
         </p>
-        <SyntaxHighlighter language='typescript'>
+        <Code language='typescript'>
           {`interface Storage
 {
   store(data: FinishedSet, now: Date): void;
 }`}
-        </SyntaxHighlighter>
+        </Code>
       </div>
     </div>
   </>}


### PR DESCRIPTION
The highlight now works in light and dark mode.
fixes #237

# The Pull Request is ready

- [x] fixes #237 
- [x] all actions are passing
- [x] only fixes a single issue

## Overview

Custom styles are provided instead of inline ones, so a switch between light and dark mode is possible.

## Website

- [x] mobile view is usable
- [x] desktop view is usable
- [x] no a-tags are used directly (NavLink, MailLink, ExternalLink instead)
- [x] all new texts are added to the translation files (at least the english one)
- [x] tests have been added (if required)
- [x] shared code has been extracted in a different file
