### PR TITLE
feature(documentation-website): add Tool component for listing tools

### DIFF
--- a/documentation-website/src/components/tool.tsx
+++ b/documentation-website/src/components/tool.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface ToolType {
+  name: string;
+  imgSrc?: string;
+  desc: string;
+  link: string
+}
+
+const Tool = ({
+  name, imgSrc, desc, link,
+}: ToolType,) => {
+
+  const Image = imgSrc ? <img src={imgSrc} alt={name}/> : '';
+
+  return <div>
+    <a
+      href={link}
+      target='_blank'
+      rel='noreferrer'
+    >
+      <h3>{name}</h3>
+    </a>
+    {Image}
+    <p>{desc}</p>
+  </div>;
+};
+
+export default Tool;
+

--- a/documentation-website/test/components/social-link.ts
+++ b/documentation-website/test/components/social-link.ts
@@ -3,7 +3,7 @@ import {
   expect,
 } from 'chai';
 
-describe('components/breadcrumbs', () => {
+describe('components/social-link', () => {
   it('should be a function', () => {
     expect(SL,).to.be.a('function',);
   },);

--- a/documentation-website/test/components/tool.ts
+++ b/documentation-website/test/components/tool.ts
@@ -1,0 +1,19 @@
+import Tool from '../../src/components/tool.tsx';
+import {
+  expect,
+} from 'chai';
+
+describe('components/tool', () => {
+  it('should be a function', () => {
+    expect(Tool,).to.be.a('function',);
+  },);
+  it('() should be an object', () => {
+    const result = Tool({
+      name: 'example',
+      imgSrc: '/',
+      desc: 'example desc',
+      link: '/',
+    },);
+    expect(result,).to.be.a('object',);
+  },);
+},);


### PR DESCRIPTION
# The Pull Request is ready

- [x] fixes #420 
- [x] all actions are passing
- [x] only fixes a single issue

## Overview

add Tool component for listing tools used on the website

## Documentation-Website

- [x] mobile view is usable
- [x] desktop view is usable
- [ ] no a-tags are used directly (NavLink, MailLink, ExternalLink instead)
- [ ] all new texts are added to the translation files (at least the english one)
- [x] tests have been added (if required)
- [x] shared code has been extracted in a different file
