### PR TITLE
fix(website): remove home button from nav

### DIFF
--- a/documentation-website/cypress/e2e/home.cy.ts
+++ b/documentation-website/cypress/e2e/home.cy.ts
@@ -19,7 +19,7 @@ describe('home', () => {
       .should('eq', 'What does this project do?',);
   },);
   it('link to self exists', () => {
-    cy.get('header div a[href="/"]')
+    cy.get('header div a[href="/"]',)
       .find('img',)
       .should('exist',);
   },);
@@ -37,3 +37,4 @@ describe('home', () => {
       );
   },);
 },);
+

--- a/documentation-website/cypress/e2e/home.cy.ts
+++ b/documentation-website/cypress/e2e/home.cy.ts
@@ -19,9 +19,9 @@ describe('home', () => {
       .should('eq', 'What does this project do?',);
   },);
   it('link to self exists', () => {
-    cy.get('header nav a[href="/"]',)
-      .invoke('text',)
-      .should('eq', 'Home',);
+    cy.get('header div a[href="/"]')
+      .find('img',)
+      .should('exist',);
   },);
   it('breadcrumbs exists', () => {
     cy.get('nav.breadcrumbs li:last-of-type',)

--- a/documentation-website/src/components/header.tsx
+++ b/documentation-website/src/components/header.tsx
@@ -19,7 +19,9 @@ const Header = ({
   window,
 }: {window: Window},) => <header>
   <div>
-    <img src={IAB} alt="@idrinth/api-bench" />
+    <NavLink to="/">
+      <img src={IAB} alt="@idrinth/api-bench" />
+    </NavLink>
     <strong>@idrinth/api-bench</strong>
     <em>v{pkg.version}</em>
   </div>
@@ -54,9 +56,6 @@ const Header = ({
   </nav>
   <nav>
     <ul>
-      <li>
-        <NavLink to="/"><Lang lnkey='nav.home'/></NavLink>
-      </li>
       <li>
         <NavLink to="/quick-start/">
           <Lang lnkey='nav.quick-start'/>


### PR DESCRIPTION
Remove the navigation link to the home button and integrate its function into the website's logo. This change is made to streamline the navigation bar, making it less cluttered and utilizing the previously underused logo as the new home navigation point.

Closes #553

# The Pull Request is ready

- [x] fixes #553
- [ ] all actions are passing
- [x] only fixes a single issue

## Overview

<!-- Provide a brief description of the changes introduced by this
Pull Request. -->

## Review points

<!-- List the points to be reviewed in detail 
and the points you are not confident about. -->
<!-- Delete this section if not needed -->

## Documentation-Website

- [ ] mobile view is usable
- [ ] desktop view is usable
- [ ] no a-tags are used directly (NavLink, MailLink, ExternalLink instead)
- [ ] all new texts are added to the translation files (at least the english one)
- [ ] tests have been added (if required)
- [ ] shared code has been extracted in a different file

## Notes

<!-- Write any note or comment. You can share your thoughts or ideas. -->
<!-- Delete this section if not needed -->
