### PR TITLE
Fix low contrast text on light them

### DIFF
--- a/documentation-website/src/index.css
+++ b/documentation-website/src/index.css
@@ -73,7 +73,7 @@ header {
   width: 100%;
   display: grid;
   grid-template-columns: 90% 10%;
-  background-color: var(--light-gray);
+  background-color: var(--white);
   padding-bottom: 1em;
   padding-top: 1em;
 }
@@ -157,7 +157,7 @@ footer {
   display: grid;
   grid-template-columns: 1fr;
   padding: 1rem 1em;
-  background-color: var(--light-gray);
+  background-color: var(--white);
   width: 100%;
 }
 
@@ -400,7 +400,7 @@ nav.breadcrumbs li:last-of-type::after {
     gap: 1em;
     width: auto;
     position: absolute;
-    background: var(--light-gray);
+    background: var(--white);
     padding: 1em;
     box-shadow: 1em 1em 1.5em var(--dark-gray);
   }

--- a/documentation-website/src/index.css
+++ b/documentation-website/src/index.css
@@ -76,6 +76,7 @@ header {
   background-color: var(--white);
   padding-bottom: 1em;
   padding-top: 1em;
+  box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px, rgb(51, 51, 51) 0px 0px 0px 3px;
 }
 
 header button {
@@ -159,6 +160,7 @@ footer {
   padding: 1rem 1em;
   background-color: var(--white);
   width: 100%;
+  box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px, rgb(51, 51, 51) 0px 0px 0px 3px;
 }
 
 footer ul {
@@ -478,6 +480,7 @@ nav.breadcrumbs li:last-of-type::after {
   .dark-mode header,
   .dark-mode footer {
     background-color: var(--very-dark-gray);
+    box-shadow: none;
   }
 
   .dark-mode pre {

--- a/documentation-website/src/index.css
+++ b/documentation-website/src/index.css
@@ -76,7 +76,7 @@ header {
   background-color: var(--white);
   padding-bottom: 1em;
   padding-top: 1em;
-  box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px, rgb(51, 51, 51) 0px 0px 0px 3px;
+  box-shadow: rgb(0 0 0 / 16%) 0 1px 4px, rgb(51 51 51) 0 0 0 3px;
 }
 
 header button {

--- a/documentation-website/src/index.css
+++ b/documentation-website/src/index.css
@@ -76,7 +76,6 @@ header {
   background-color: var(--white);
   padding-bottom: 1em;
   padding-top: 1em;
-  box-shadow: rgb(0 0 0 / 16%) 0 1px 4px, rgb(51 51 51) 0 0 0 3px;
 }
 
 header button {
@@ -160,7 +159,11 @@ footer {
   padding: 1rem 1em;
   background-color: var(--white);
   width: 100%;
-  box-shadow: rgba(0, 0, 0, 0.16) 0px 1px 4px, rgb(51, 51, 51) 0px 0px 0px 3px;
+}
+
+header,
+footer {
+  box-shadow: rgb(0 0 0 / 16%) 0 1px 4px, rgb(51 51 51) 0 0 0 3px;
 }
 
 footer ul {


### PR DESCRIPTION
# The Pull Request is ready

- [ ] fixes #582 
- [ ] all actions are passing
- [ ] only fixes a single issue

## Overview

Header, navigation sub links list and Footer use '--white' color var to avoid problems with low-contrast

## Documentation-Website

- [ ] mobile view is usable
- [ ] desktop view is usable
- [ ] no a-tags are used directly (NavLink, MailLink, ExternalLink instead)
- [ ] all new texts are added to the translation files (at least the english one)
- [ ] tests have been added (if required)
- [ ] shared code has been extracted in a different file

## Notes
I decided to use box-shadow as a border to separate the header and footer in a light theme and avoid collapsing the layout
<!-- Delete this section if not needed -->
