### PR TITLE
feature(documentation-website): allow title and alt on social icons

### DIFF
--- a/documentation-website/language/en.yml
+++ b/documentation-website/language/en.yml
@@ -17,6 +17,23 @@ nav:
   faq: "FAQ"
   code-of-conduct: "Code of Conduct"
 
+socials:
+  npm-main:
+    title: "@idrinth/api-bench on NPM"
+    alt: "NPM"
+  github:
+    title: "idrinth/api-bench on GitHub"
+    alt: "GitHub"
+  youtube:
+    title: "idrinth-api-bench on youtube"
+    alt: "YouTube"
+  slack:
+    title: "@idrinth/api-bench on slack"
+    alt: "Slack"
+  linkedin:
+    title: "@idrinth/api-bench on LinkedIN"
+    alt: "LinkedIn"
+
 code-of-conduct:
   meta:
     title: "Code of Conduct"

--- a/documentation-website/src/components/header.tsx
+++ b/documentation-website/src/components/header.tsx
@@ -29,7 +29,8 @@ const Header = ({
     <ul>
       <SocialLink
         to="https://www.npmjs.com/package/@idrinth/api-bench"
-        label={'npm'}
+        label={'npm-main'}
+        logo={'npm'}
       />
       <SocialLink
         to="https://github.com/Idrinth/api-bench"

--- a/documentation-website/src/components/social-link.tsx
+++ b/documentation-website/src/components/social-link.tsx
@@ -1,4 +1,7 @@
-import React, {lazy, Suspense} from 'react';
+import React, {
+  lazy,
+  Suspense,
+} from 'react';
 import {
   FiExternalLink,
 } from 'react-icons/fi';

--- a/documentation-website/src/components/social-link.tsx
+++ b/documentation-website/src/components/social-link.tsx
@@ -1,25 +1,46 @@
-import React from 'react';
+import React, {lazy, Suspense} from 'react';
 import {
   FiExternalLink,
 } from 'react-icons/fi';
+import t from './t.ts';
+import languageKey from '../locales/language-key.ts';
 
 interface SocialLinkType {
   to: string;
   label: string;
+  logo?: string;
 }
 const SocialLink = ({
   to,
   label,
-}: SocialLinkType,) => <li id={label}>
-  <a
-    href={to}
-    className="external-link"
-    target='_blank'
-    rel='noreferrer'
-    title={label}
-  >
-    <img alt={label} src={'/assets/' + label + '.svg'}/>
-    <FiExternalLink className="external-link-icon" />
-  </a>
-</li>;
+  logo,
+}: SocialLinkType,) => {
+  const EL = lazy(async() => {
+    const title = await t(`socials.${ label }.title` as languageKey,);
+    const alt = await t(`socials.${ label }.alt` as languageKey,);
+    return {
+      default: () => <a
+        href={to}
+        className="external-link"
+        target='_blank'
+        rel='noreferrer'
+        title={title}
+      >
+        <img alt={alt} src={'/assets/' + (logo ?? label) + '.svg'}/>
+        <FiExternalLink className="external-link-icon"/>
+      </a>,
+    };
+  },);
+  return <li id={label}>
+    <Suspense fallback={<a
+      href={to}
+      className="external-link"
+      target='_blank'
+      rel='noreferrer'
+    >
+      <img alt={''} src={'/assets/' + (logo ?? label) + '.svg'}/>
+      <FiExternalLink className="external-link-icon" />
+    </a>}><EL/></Suspense>
+  </li>;
+};
 export default SocialLink;

--- a/documentation-website/test/components/social-link.ts
+++ b/documentation-website/test/components/social-link.ts
@@ -11,6 +11,7 @@ describe('components/social-link', () => {
     const result = SL({
       to: '/',
       label: '',
+      logo: '',
     },);
     expect(result,).to.be.a('object',);
   },);


### PR DESCRIPTION
# The Pull Request is ready

- [ ] all actions are passing
- [ ] only fixes a single issue

## Overview

Social icons can now be  given translatable titles and  alt texts

## Documentation-Website

- [ ] mobile view is usable
- [ ] desktop view is usable
- [ ] no a-tags are used directly (NavLink, MailLink, ExternalLink instead)
- [ ] all new texts are added to the translation files (at least the english one)
- [ ] tests have been added (if required)
- [ ] shared code has been extracted in a different file