### PR TITLE
fix too wide code boxes

### DIFF
--- a/documentation-website/src/index.css
+++ b/documentation-website/src/index.css
@@ -500,7 +500,7 @@ html.dark-mode {
 
   .card {
     display: grid;
-    grid-template-columns: 1fr 2fr;
+    grid-template-columns: 1fr minmax(100px, 2fr);
     background: rgba(0 0 0 / 10%);
     box-shadow: rgba(0 0 0 / 50%) 0.5em 0.5em 1em;
     border: var(--dark-green) solid 1px;


### PR DESCRIPTION
# The Pull Request is ready

- [ ] fixes #622 
- [ ] all actions are passing
- [ ] only fixes a single issue

## Overview

I changed the value of ".grid-template-columns" from "1fr 2f" to "1fr minmax(100px, 2fr)" 

## Documentation-Website

- [x] mobile view is usable
- [x] desktop view is usable
- [x] no a-tags are used directly (NavLink, MailLink, ExternalLink instead)
## Notes
I checked all the cards and window sizes, everything should work. 
I think the first column ".card" should be a little smaller

