### PR TITLE
fix(framework): wrong type intersection in multi-reporter

### DIFF
--- a/framework/src/reporter/multi-reporter-type.ts
+++ b/framework/src/reporter/multi-reporter-type.ts
@@ -1,0 +1,7 @@
+import ReporterList from './reporter-list.js';
+import Reporter from './reporter.js';
+
+interface MultiReporterType extends ReporterList, Reporter {
+}
+
+export default MultiReporterType;

--- a/framework/src/reporter/multi-reporter.ts
+++ b/framework/src/reporter/multi-reporter.ts
@@ -1,14 +1,9 @@
 import Reporter from './reporter.js';
 import FinishedRun from '../finished-run.js';
-
-interface ReporterList {
-  addReporter: (reporter: Reporter) => void;
-}
-
-interface MultiReporterType extends ReporterList, Reporter {
-}
+import MultiReporterType from './multi-reporter-type.js';
 
 const reporters: Array<Reporter> = [];
+
 const multi: MultiReporterType = (
   results: FinishedRun,
   rootDir: string,

--- a/framework/src/reporter/multi-reporter.ts
+++ b/framework/src/reporter/multi-reporter.ts
@@ -5,8 +5,11 @@ interface ReporterList {
   addReporter: (reporter: Reporter) => void;
 }
 
+interface MultiReporterType extends ReporterList, Reporter {
+}
+
 const reporters: Array<Reporter> = [];
-const multi: Reporter&ReporterList = (
+const multi: MultiReporterType = (
   results: FinishedRun,
   rootDir: string,
 ): void => {

--- a/framework/src/reporter/reporter-list.ts
+++ b/framework/src/reporter/reporter-list.ts
@@ -1,0 +1,7 @@
+import Reporter from './reporter.js';
+
+interface ReporterList {
+  addReporter: (reporter: Reporter) => void;
+}
+
+export default ReporterList;


### PR DESCRIPTION
Addressed sonar cloud bug , indicating wrong type intersection in  framework/src/reporter/multi-reporter.ts:9

Closes #514

# The Pull Request is ready

- [x] fixes #514 <!-- YOUR ISSUE ID HERE -->
- [x] all actions are passing
- [x] only fixes a single issue

## Overview

Introduced a new local interface MultiReporterType which extends ReporterList & Reporter , this will replace the existing intersection type.
This will help sove the sonar issue https://sonarcloud.io/project/issues?open=AY3BCwwQON117fWgsitg&id=Idrinth_api-bench&tab=code

## Review points

Need review on the new interface/type name.

## Framework

- [x] the change breaks no interface
- [x] default behaviour did not change
- [ ] any new text output is added to the translation files (at least the english one)
- [ ] tests have been added (if required)
- [ ] documentation has been adjusted (if required)
- [ ] shared code has been extracted in a different file
