### PR TITLE
XML Validator class name

### DIFF
--- a/framework/src/middlewares/xml-validator.ts
+++ b/framework/src/middlewares/xml-validator.ts
@@ -4,13 +4,13 @@ import Request from '../request.js';
 import Result from '../result.js';
 import language from '../helper/language.js';
 import {
-  XMLValidator,
+  XMLValidator as FastXMLValidator,
 } from 'fast-xml-parser';
 
 const xmlCheck = /\/xml/ui;
 
 @staticImplements<Middleware>()
-export default class JsonValidator {
+export default class XMLValidator {
   public static prepare(request: Request,): Request {
     return request;
   }
@@ -23,7 +23,7 @@ export default class JsonValidator {
     if (! xmlCheck.test(contentType,)) {
       throw Error(language('no_xml_content_type', contentType,),);
     }
-    if (XMLValidator.validate(result.response.body,) !== true) {
+    if (FastXMLValidator.validate(result.response.body,) !== true) {
       throw Error(language('invalid_xml_body',),);
     }
   }

--- a/framework/test/middlewares/xml-validator.ts
+++ b/framework/test/middlewares/xml-validator.ts
@@ -5,7 +5,7 @@ import {
 import 'mocha';
 import Result from '../../src/result.js';
 
-describe('middlewares/json-validator', () => {
+describe('middlewares/xml-validator', () => {
   it('should be a class', () => {
     expect(XMLValidator,).to.be.a('function',);
   },);
@@ -41,7 +41,7 @@ describe('middlewares/json-validator', () => {
       expect(() => XMLValidator.process(response,),)
         .to.throw('The content-type header is missing.',);
     },);
-    it('should throw if the type is not json', () => {
+    it('should throw if the type is not xml', () => {
       const response: Result = {
         id: 'example',
         validators: [],
@@ -61,7 +61,7 @@ describe('middlewares/json-validator', () => {
           'The content-type application/jason is not */xml.',
         );
     },);
-    it('should throw if the body is not json', () => {
+    it('should throw if the body is not xml', () => {
       const response: Result = {
         id: 'example',
         validators: [],


### PR DESCRIPTION
# The Pull Request is ready

- [x] fixes #637 
- [x] all actions are passing
- [x] only fixes a single issue

## Overview

Changed the XMLValidator class name and XMLValidator tests description as both were referring to "JSON".

## Framework

- [x] the change breaks no interface
- [x] default behaviour did not change
- [ ] any new text output is added to the translation files (at least the english one)
- [ ] tests have been added (if required)
- [ ] documentation has been adjusted (if required)
- [ ] shared code has been extracted in a different file
