### PR TITLE
feature(documentation-website): make cookie consent  more specific

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -17,6 +17,7 @@ Idrinth's
 JSON
 Javascript
 LinkedIN
+Matomo
 Microservice
 Middleware
 Middlewares
@@ -86,8 +87,10 @@ rest-APIs
 sexualised
 src
 subprojects
+tracking.bjoern-buettner.me
 ui
 webmaster@idrinth-api-ben.ch
 winston
 www.contributor-covenant.org
+www.youtube-nocookie.com
 xml

--- a/documentation-website/language/en.yml
+++ b/documentation-website/language/en.yml
@@ -469,3 +469,11 @@ cookie-consent:
   description: "We use cookies to ensure you get the best experience on our website."
   accept: "Accept"
   decline: "Decline"
+  custom: "As above"
+  service:
+    tracking:
+      title: "Matomo tracking"
+      description: "We will track your visit via tracking.bjoern-buettner.me to improve out content."
+    youtube:
+      title: "YouTube"
+      description: "We will load videos from www.youtube-nocookie.com to directly play on the site."

--- a/documentation-website/src/components/cookie-consent-service.tsx
+++ b/documentation-website/src/components/cookie-consent-service.tsx
@@ -1,0 +1,45 @@
+import React, {
+  lazy,
+  Suspense,
+} from 'react';
+import {
+  get,
+} from './local-consent-storage.ts';
+import Lang from './lang.tsx';
+import languageKey from '../locales/language-key.ts';
+import t from './t.ts';
+
+const CookieConsentService = ({
+  children,
+}: {children: string},) => {
+  const EL = lazy(async() => {
+    const title = await t(
+      `cookie-consent.service.${ children }.description` as languageKey,
+    );
+    return {
+      default: () => <label
+        htmlFor={children + '-consent'}
+        title={title}
+      >
+        <Lang lnkey={
+          `cookie-consent.service.${ children }.title` as languageKey
+        }/>
+      </label>,
+    };
+  },);
+  return <li key={children + '-consent'} className={'service'}>
+    <input
+      id={children + '-consent'}
+      type={'checkbox'}
+      defaultChecked={get(children,)}
+    />
+    <Suspense fallback={<label
+      htmlFor={children + '-consent'}
+    >
+      <Lang lnkey={`cookie-consent.service.${children
+      }.title` as languageKey}/>
+    </label>}><EL/></Suspense>
+  </li>;
+};
+
+export default CookieConsentService;

--- a/documentation-website/src/components/cookie-consent-service.tsx
+++ b/documentation-website/src/components/cookie-consent-service.tsx
@@ -36,7 +36,7 @@ const CookieConsentService = ({
     <Suspense fallback={<label
       htmlFor={children + '-consent'}
     >
-      <Lang lnkey={`cookie-consent.service.${children
+      <Lang lnkey={`cookie-consent.service.${ children
       }.title` as languageKey}/>
     </label>}><EL/></Suspense>
   </li>;

--- a/documentation-website/src/components/cookie-consent.css
+++ b/documentation-website/src/components/cookie-consent.css
@@ -29,6 +29,7 @@
 .cookie-consent li {
   display: block;
 }
+
 .cookie-consent ul {
   padding: 1em 0;
 }

--- a/documentation-website/src/components/cookie-consent.css
+++ b/documentation-website/src/components/cookie-consent.css
@@ -25,14 +25,39 @@
   font-size: 1.2em;
 }
 
+.cookie-consent ul,
+.cookie-consent li {
+  display: block;
+}
+.cookie-consent ul {
+  padding: 1em 0;
+}
+
+.cookie-consent li.service {
+  display: flex;
+  gap: 1em;
+}
+
+.cookie-consent li.service input {
+  width: 1em;
+  height: 1em;
+  border: 1px solid var(--dark-green);
+}
+
+.cookie-consent li.service input:checked {
+  background: var(--dark-green);
+}
+
 .cookie-consent .cookie-consent-buttons {
   display: flex;
   justify-content: flex-start;
   width: 100%;
+  gap: 0.5em;
 }
 
 .cookie-consent .cookie-consent-accept-button,
-.cookie-consent .cookie-consent-decline-button {
+.cookie-consent .cookie-consent-decline-button ,
+.cookie-consent .cookie-consent-custom-button {
   padding: 20px;
   border-radius: 10px;
   cursor: pointer;
@@ -47,12 +72,14 @@
   background-color: var(--light-green);
 }
 
-.cookie-consent .cookie-consent-decline-button {
+.cookie-consent .cookie-consent-decline-button,
+.cookie-consent .cookie-consent-custom-button {
   background-color: var(--light-gray);
-  color: --black;
+  color: var(--black);
 }
 
-.cookie-consent .cookie-consent-decline-button:hover {
+.cookie-consent .cookie-consent-decline-button:hover,
+.cookie-consent .cookie-consent-custom-button:hover {
   background-color: rgb(167 173 179);
 }
 
@@ -64,15 +91,13 @@
   color: var(--light-gray);
 }
 
-.dark-mode .cookie-consent .cookie-consent-decline-button {
+.dark-mode .cookie-consent .cookie-consent-decline-button,
+.dark-mode .cookie-consent .cookie-consent-custom-button {
   color: var(--white);
   background-color: var(--dark-gray);
 }
 
-.cookie-consent .cookie-consent-decline-button {
-  margin-left: 10px;
-}
-
-.dark-mode .cookie-consent .cookie-consent-decline-button:hover {
+.dark-mode .cookie-consent .cookie-consent-decline-button:hover,
+.dark-mode .cookie-consent .cookie-consent-ccustom-button:hover {
   opacity: 80%;
 }

--- a/documentation-website/src/components/cookie-consent.tsx
+++ b/documentation-website/src/components/cookie-consent.tsx
@@ -14,7 +14,7 @@ import {
   get,
   set,
 } from './local-consent-storage.ts';
-import CookieConsentService from "./cookie-consent-service.tsx";
+import CookieConsentService from './cookie-consent-service.tsx';
 
 // eslint-disable-next-line complexity
 const CookieConsent = () => {
@@ -39,6 +39,7 @@ const CookieConsent = () => {
       : 'forgetConsentGiven', ],);
   }
 
+  // eslint-disable-next-line complexity
   const handleConsent = (accept: null|boolean,) => {
     if (typeof accept === 'boolean') {
       const elements = document
@@ -52,13 +53,13 @@ const CookieConsent = () => {
       }
       accept = null;
     }
-    for  (const type  of types) {
+    for (const type of types) {
       const allow = document
         .getElementById(type + '-consent',)
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-expect-error
         ?.checked;
-      set(type, allow);
+      set(type, allow,);
     }
     //@ts-expect-error _paq can be null
     window?._paq?.push([ get('tracking',)

--- a/documentation-website/src/components/local-consent-storage.ts
+++ b/documentation-website/src/components/local-consent-storage.ts
@@ -2,7 +2,7 @@ export const get = (key: string,) => localStorage.getItem(
   key + '-consent',
 ) === 'true';
 export const has = (key: string,) => !! localStorage.getItem(key + '-consent',);
-export const set = (key: string, value: boolean) => localStorage.setItem(
+export const set = (key: string, value: boolean,) => localStorage.setItem(
   key + '-consent',
   value ? 'true' : 'false',
 );

--- a/documentation-website/src/components/local-consent-storage.ts
+++ b/documentation-website/src/components/local-consent-storage.ts
@@ -1,0 +1,8 @@
+export const get = (key: string,) => localStorage.getItem(
+  key + '-consent',
+) === 'true';
+export const has = (key: string,) => !! localStorage.getItem(key + '-consent',);
+export const set = (key: string, value: boolean) => localStorage.setItem(
+  key + '-consent',
+  value ? 'true' : 'false',
+);

--- a/documentation-website/src/components/youtube-content.tsx
+++ b/documentation-website/src/components/youtube-content.tsx
@@ -12,6 +12,9 @@ import {
   YOUTUBE_DEFAULT_WIDTH,
   YOUTUBE_RECHECK_TIME,
 } from '../constants.ts';
+import {
+  get,
+} from './local-consent-storage.ts';
 
 interface YoutubeContentType {
   children: string;
@@ -34,7 +37,7 @@ const YoutubeContent = ({
   ] = useState<boolean>(localStorage.getItem('consent-was-given',) === 'true',);
   if (! allowed) {
     const interval = setInterval(() => {
-      if (localStorage.getItem('consent',) === 'true') {
+      if (get('youtube',)) {
         clearInterval(interval,);
         setAllowed(true,);
       }

--- a/documentation-website/src/constants.ts
+++ b/documentation-website/src/constants.ts
@@ -10,3 +10,4 @@ export const YOUTUBE_DEFAULT_WIDTH =560;
 export const YOUTUBE_DEFAULT_HEIGHT= 315;
 export const STRING_START = 0;
 export const STRING_PX_OFFSET = 3;
+export const EMPTY =  0;

--- a/documentation-website/src/constants.ts
+++ b/documentation-website/src/constants.ts
@@ -10,4 +10,4 @@ export const YOUTUBE_DEFAULT_WIDTH =560;
 export const YOUTUBE_DEFAULT_HEIGHT= 315;
 export const STRING_START = 0;
 export const STRING_PX_OFFSET = 3;
-export const EMPTY =  0;
+export const EMPTY = 0;


### PR DESCRIPTION
# The Pull Request is ready

- [x] fixes #661 
- [x] all actions are passing
- [x] only fixes a single issue

## Overview

-  services can now be (de)selected

## Documentation-Website

- [x] mobile view is usable
- [x] desktop view is usable
- [x] no a-tags are used directly (NavLink, MailLink, ExternalLink instead)
- [x] all new texts are added to the translation files (at least the english one)
- [x] tests have been added (if required)
- [x] shared code has been extracted in a different file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
    - Introduced a new `CookieConsentService` component for handling cookie consent with dynamic checkbox generation.
    - Added custom text options for cookie consent, including details for Matomo tracking and YouTube video loading.
- **Style**
    - Updated styling for cookie consent elements, including list items, buttons, and hover effects for improved user interaction.
- **Documentation**
    - Enhanced documentation with service-specific details for better clarity on cookie consent functionality.
- **Refactor**
    - Improved cookie consent logic with efficient rendering techniques such as lazy loading and suspense.
    - Refined consent management with new local storage functions for checking and setting consent values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->