### PR TITLE
Issue 707 event instead of interval

### DIFF
--- a/documentation-website/src/components/local-consent-storage.ts
+++ b/documentation-website/src/components/local-consent-storage.ts
@@ -2,7 +2,16 @@ export const get = (key: string,) => localStorage.getItem(
   key + '-consent',
 ) === 'true';
 export const has = (key: string,) => !! localStorage.getItem(key + '-consent',);
-export const set = (key: string, value: boolean,) => localStorage.setItem(
-  key + '-consent',
-  value ? 'true' : 'false',
-);
+export const set = (key: string, value: boolean,) => {
+  localStorage.setItem(
+    key + '-consent',
+    value ? 'true' : 'false',
+  );
+  const event = new CustomEvent('consentChanged', {
+    detail: {
+      key,
+      value,
+    },
+  },);
+  document.body.dispatchEvent(event,);
+};

--- a/documentation-website/src/components/youtube-content.tsx
+++ b/documentation-website/src/components/youtube-content.tsx
@@ -10,7 +10,6 @@ import {
   STRING_START,
   YOUTUBE_DEFAULT_HEIGHT,
   YOUTUBE_DEFAULT_WIDTH,
-  YOUTUBE_RECHECK_TIME,
 } from '../constants.ts';
 import {
   get,
@@ -34,14 +33,17 @@ const YoutubeContent = ({
   const [
     allowed,
     setAllowed,
-  ] = useState<boolean>(localStorage.getItem('consent-was-given',) === 'true',);
+  ] = useState<boolean>(get('youtube',),);
   if (! allowed) {
-    const interval = setInterval(() => {
-      if (get('youtube',)) {
-        clearInterval(interval,);
-        setAllowed(true,);
+    document.body.addEventListener('consentChanged', (event,) => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
+      if (event?.detail?.key === 'youtube') {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-expect-error
+        setAllowed(event?.detail?.value ?? false,);
       }
-    }, YOUTUBE_RECHECK_TIME,);
+    },);
     return <YoutubeLink>{children}</YoutubeLink>;
   }
   const EL = lazy(async() => {

--- a/documentation-website/src/constants.ts
+++ b/documentation-website/src/constants.ts
@@ -5,7 +5,6 @@ export const SCROLL_WAIT_TIME = 100;
 export const DEFAULT_RADIX = 10;
 export const INDENTATION_SPACES = 2;
 export const INITIAL_ZERO = 0;
-export const YOUTUBE_RECHECK_TIME = 250;
 export const YOUTUBE_DEFAULT_WIDTH =560;
 export const YOUTUBE_DEFAULT_HEIGHT= 315;
 export const STRING_START = 0;


### PR DESCRIPTION
# The Pull Request is ready

- [x] fixes #707
- [x] all actions are passing
- [x] only fixes a single issue

## Overview

- replacing interval with event

## Documentation-Website

- [x] mobile view is usable
- [x] desktop view is usable
- [x] no a-tags are used directly (NavLink, MailLink, ExternalLink instead)
- [x] all new texts are added to the translation files (at least the english one)
- [x] tests have been added (if required)
- [x] shared code has been extracted in a different file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the consent change notification mechanism by dispatching custom events.
- **Refactor**
	- Updated YouTube content handling to listen for consent change events instead of using a timed recheck.
	- Removed unused constants and added default dimensions for YouTube embeds.
- **Documentation**
	- Not explicitly mentioned, but changes in code behavior suggest potential updates in documentation regarding consent handling and YouTube content embedding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->