### PR TITLE
docs(documentation-website):Add npm run local to Contributor Guidelines 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ npm run coai
 
 #### Running Tests Locally
 
-To see a list of available CI tasks and their corresponding commands to run them locally you can run `npm run local` in the source folder.This is particularly useful for testing specific CI tasks before committing your changes.
+To see a list of available CI tasks and their corresponding commands to run them locally you can run `npm run local` in the source folder. This is particularly useful for testing specific CI tasks before committing your changes.
 
 ```bash
 git clone https://github.com/idrinth/api-bench

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,15 @@ git clone https://github.com/idrinth/api-bench
 cd api-bench
 npm run coai
 ```
+#### Running Tests Locally
+
+`npm run local` will now output any ci task you can run locally with the command you need to use. Add that as an option to test ahead of committing or when an action fails.
+
+```bash
+git clone https://github.com/idrinth/api-bench
+cd api-bench
+npm run local
+```
 
 ### Naming conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ npm run coai
 
 #### Running Tests Locally
 
-To see a list of available CI tasks and their corresponding commands to run them locally you can run `npm run local` in the source folder. This is particularly useful for testing specific CI tasks before committing your changes.
+To see a list of available CI tasks and their corresponding commands to run them locally, you can run `npm run local` in the source folder. This is particularly useful for testing specific CI tasks before committing your changes.
 
 ```bash
 git clone https://github.com/idrinth/api-bench

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,8 +116,8 @@ npm run coai
 
 #### Running Tests Locally
 
-To see a list of available CI tasks and their corresponding commands to run them 
-locally, you can run `npm run local` in the source folder. This is particularly 
+To see a list of available CI tasks and their corresponding commands to run them
+locally, you can run `npm run local` in the source folder. This is particularly
 useful for testing specific CI tasks before committing your changes.
 
 ### Naming conventions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,13 +116,9 @@ npm run coai
 
 #### Running Tests Locally
 
-To see a list of available CI tasks and their corresponding commands to run them locally, you can run `npm run local` in the source folder. This is particularly useful for testing specific CI tasks before committing your changes.
-
-```bash
-git clone https://github.com/idrinth/api-bench
-cd api-bench
-npm run local
-```
+To see a list of available CI tasks and their corresponding commands to run them 
+locally, you can run `npm run local` in the source folder. This is particularly 
+useful for testing specific CI tasks before committing your changes.
 
 ### Naming conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ npm run coai
 ```
 #### Running Tests Locally
 
-`npm run local` will now output any ci task you can run locally with the command you need to use. Add that as an option to test ahead of committing or when an action fails.
+To see a list of available CI tasks and their corresponding commands to run them locally you can run `npm run local` in the source folder.This is particularly useful for testing specific CI tasks before committing your changes.
 
 ```bash
 git clone https://github.com/idrinth/api-bench

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,7 @@ git clone https://github.com/idrinth/api-bench
 cd api-bench
 npm run coai
 ```
+
 #### Running Tests Locally
 
 To see a list of available CI tasks and their corresponding commands to run them locally you can run `npm run local` in the source folder.This is particularly useful for testing specific CI tasks before committing your changes.


### PR DESCRIPTION
# The Pull Request is ready

- [x] fixes #736 
- [x] all actions are passing
- [x] only fixes a single issue

## Overview

This pull request addresses the issue by updating the contributor guidelines to include instructions for running Continuous Integration (CI) tasks locally using the npm run local command. 


## Documentation-Website

- [ ] mobile view is usable
- [ ] desktop view is usable
- [x] no a-tags are used directly (NavLink, MailLink, ExternalLink instead)
- [ ] all new texts are added to the translation files (at least the english one)
- [ ] tests have been added (if required)
- [ ] shared code has been extracted in a different file


