### PR TITLE
bug(documentation-website): fixed overlap issue between socials and footer

### DIFF
--- a/documentation-website/src/components/footer.scss
+++ b/documentation-website/src/components/footer.scss
@@ -35,6 +35,7 @@ footer {
       max-height: 100%;
       white-space: nowrap;
     }
+
     ul {
       padding-bottom: 0;
     }

--- a/documentation-website/src/components/footer.scss
+++ b/documentation-website/src/components/footer.scss
@@ -25,12 +25,18 @@ footer {
     display: flex;
     gap: 1em;
     padding-left: 0;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding-bottom: 2rem;
   }
 
   @media only screen and (width >= 600px) {
     span {
       max-height: 100%;
       white-space: nowrap;
+    }
+    ul {
+      padding-bottom: 0;
     }
   }
 


### PR DESCRIPTION
…ooter on smaller screens.

closes  #922

# The Pull Request is ready

- [x] fixes #922 
- [ ] all actions are passing
- [x] only fixes a single issue

## Overview

Fixed overlap between socials and footer for smaller screens. Previously, the footer could not be seen which also caused a wide space on the right side of the screen.


## Documentation-Website

- [x] mobile view is usable
- [x] desktop view is usable
- [ ] no a-tags are used directly (NavLink, MailLink, ExternalLink instead)
- [ ] all new texts are added to the translation files (at least the english one)
- [ ] tests have been added (if required)
- [ ] shared code has been extracted in a different file
