### PR TITLE
Issue 548 - Convert examples to typescript

### DIFF
--- a/examples/jsonplaceholder.typicode.com/package.json
+++ b/examples/jsonplaceholder.typicode.com/package.json
@@ -12,5 +12,9 @@
   "engines": {
     "node": ">=20"
   },
-  "engineStrict": true
+  "engineStrict": true,
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
 }

--- a/examples/jsonplaceholder.typicode.com/package.json
+++ b/examples/jsonplaceholder.typicode.com/package.json
@@ -7,7 +7,7 @@
     "@idrinth/api-bench": "*"
   },
   "scripts": {
-    "start": "run-benchmark 2 3"
+    "start": "tsc -p tsconfig.json && run-benchmark 2 3"
   },
   "engines": {
     "node": ">=20"

--- a/examples/jsonplaceholder.typicode.com/package.json
+++ b/examples/jsonplaceholder.typicode.com/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "private": true,
+  "type": "module",
   "dependencies": {
     "@idrinth/api-bench": "*"
   },

--- a/examples/jsonplaceholder.typicode.com/src/routes/main/create-post.ts
+++ b/examples/jsonplaceholder.typicode.com/src/routes/main/create-post.ts
@@ -1,4 +1,4 @@
-module.exports = (apiRootUrl,) => ({
+export default (apiRootUrl: string,) => ({
   id: 'create post',
   main: {
     method: 'post',

--- a/examples/jsonplaceholder.typicode.com/src/routes/main/delete-post.ts
+++ b/examples/jsonplaceholder.typicode.com/src/routes/main/delete-post.ts
@@ -1,4 +1,4 @@
-module.exports = (apiRootUrl,) => ({
+export default (apiRootUrl: string,) => ({
   id: 'delete post 1',
   main: {
     method: 'delete',

--- a/examples/jsonplaceholder.typicode.com/src/routes/main/get-post.ts
+++ b/examples/jsonplaceholder.typicode.com/src/routes/main/get-post.ts
@@ -1,4 +1,4 @@
-module.exports = (apiRootUrl,) => ({
+export default (apiRootUrl: string,) => ({
   id: 'get post 1',
   main: {
     method: 'get',

--- a/examples/jsonplaceholder.typicode.com/src/routes/main/list-posts.ts
+++ b/examples/jsonplaceholder.typicode.com/src/routes/main/list-posts.ts
@@ -1,4 +1,4 @@
-module.exports = (apiRootUrl,) => ({
+export default (apiRootUrl: string,) => ({
   id: 'list posts',
   main: {
     method: 'get',

--- a/examples/jsonplaceholder.typicode.com/src/routes/main/patch-post.ts
+++ b/examples/jsonplaceholder.typicode.com/src/routes/main/patch-post.ts
@@ -1,4 +1,4 @@
-module.exports = (apiRootUrl,) => ({
+export default (apiRootUrl: string,) => ({
   id: 'patch post 454',
   main: {
     method: 'patch',

--- a/examples/jsonplaceholder.typicode.com/src/routes/main/update-post.ts
+++ b/examples/jsonplaceholder.typicode.com/src/routes/main/update-post.ts
@@ -1,4 +1,4 @@
-module.exports = (apiRootUrl) => ({
+export default (apiRootUrl: string,) => ({
   id: 'update post 1',
   main: {
     method: 'put',

--- a/examples/jsonplaceholder.typicode.com/tsconfig.json
+++ b/examples/jsonplaceholder.typicode.com/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "module": "NodeNext",
+    "lib": [],
+    "target": "ESNext",
+    "esModuleInterop": true,
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true
+  },
+  "typeRoots": [
+    "@types"
+  ],
+  "include": [
+    "src/**/*.ts"
+  ],
+  "ts-node": {
+    "transpileOnly": true,
+    "moduleTypes": {
+      "*.ts": "cjs"
+    }
+  }
+}

--- a/examples/reqres.in/package.json
+++ b/examples/reqres.in/package.json
@@ -12,5 +12,9 @@
   "engines": {
     "node": ">=20"
   },
-  "engineStrict": true
+  "engineStrict": true,
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  }
 }

--- a/examples/reqres.in/package.json
+++ b/examples/reqres.in/package.json
@@ -7,7 +7,7 @@
     "@idrinth/api-bench": "*"
   },
   "scripts": {
-    "start": "run-benchmark 2 3"
+    "start": "tsc -p tsconfig.json && run-benchmark 2 3"
   },
   "engines": {
     "node": ">=20"

--- a/examples/reqres.in/package.json
+++ b/examples/reqres.in/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "private": true,
+  "type": "module",
   "dependencies": {
     "@idrinth/api-bench": "*"
   },

--- a/examples/reqres.in/src/routes/before/login.ts
+++ b/examples/reqres.in/src/routes/before/login.ts
@@ -1,4 +1,4 @@
-module.exports = (apiRootUrl) => ({
+export default (apiRootUrl: string) => ({
   id: 'login',
   main: {
     method: 'post',

--- a/examples/reqres.in/src/routes/main/create-user.ts
+++ b/examples/reqres.in/src/routes/main/create-user.ts
@@ -1,4 +1,4 @@
-module.exports = (apiRootUrl,) => ({
+export default (apiRootUrl: string,) => ({
   id: 'create user',
   main: {
     method: 'post',

--- a/examples/reqres.in/src/routes/main/delete-user.ts
+++ b/examples/reqres.in/src/routes/main/delete-user.ts
@@ -1,4 +1,4 @@
-module.exports = (apiRootUrl) => ({
+export default (apiRootUrl: string,) => ({
   id: 'delete user',
   main: {
     method: 'delete',

--- a/examples/reqres.in/src/routes/main/list-users.ts
+++ b/examples/reqres.in/src/routes/main/list-users.ts
@@ -1,4 +1,4 @@
-module.exports = (apiRootUrl,) => ({
+export default (apiRootUrl: string,) => ({
   id: 'list users',
   main: {
     method: 'get',

--- a/examples/reqres.in/src/routes/main/patch-user.ts
+++ b/examples/reqres.in/src/routes/main/patch-user.ts
@@ -1,4 +1,4 @@
-module.exports = (apiRootUrl,) => ({
+export default (apiRootUrl: string,) => ({
   id: 'patch user',
   main: {
     method: 'patch',

--- a/examples/reqres.in/src/routes/main/single-user-not-found.ts
+++ b/examples/reqres.in/src/routes/main/single-user-not-found.ts
@@ -1,4 +1,4 @@
-module.exports = (apiRootUrl,) => ({
+export default (apiRootUrl: string,) => ({
   id: 'single user not found',
   main: {
     method: 'get',

--- a/examples/reqres.in/src/routes/main/single-user.ts
+++ b/examples/reqres.in/src/routes/main/single-user.ts
@@ -1,4 +1,4 @@
-module.exports = (apiRootUrl,) => ({
+export default (apiRootUrl: string,) => ({
   id: 'single user',
   main: {
     method: 'get',

--- a/examples/reqres.in/tsconfig.json
+++ b/examples/reqres.in/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "module": "NodeNext",
+    "lib": [],
+    "target": "ESNext",
+    "esModuleInterop": true,
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true
+  },
+  "typeRoots": [
+    "@types"
+  ],
+  "include": [
+    "src/**/*.ts"
+  ],
+  "ts-node": {
+    "transpileOnly": true,
+    "moduleTypes": {
+      "*.ts": "cjs"
+    }
+  }
+}


### PR DESCRIPTION
# The Pull Request is ready

- [x] fixes #548 
- [ ] all actions are passing
- [x] only fixes a single issue

## Overview

Converted both jsonplaceholder and reqres examples to TypeScript, making the necessary changes for it to work properly.

## Examples

- [x] the example works without any additional configuration
- [ ] the example's target has been informed and has agreed
